### PR TITLE
Added Community Mutual-Credit

### DIFF
--- a/happ-resources/community-mutual-credit/bundle.toml
+++ b/happ-resources/community-mutual-credit/bundle.toml
@@ -1,0 +1,22 @@
+
+bridges = []
+
+[[instances]]
+name = "mutual-credit-template"
+id = "mutual-credit-template"
+dna_hash = "QmXAfJ2kWkP191V3CRmonKpJRpqHvUVGa7CbL4F8jiojTy"
+uri = "https://github.com/holochain-open-dev/community-mutual-credit/releases/download/test-0/community-currency.dna.json"
+
+[[instances]]
+name = "lobby-instance"
+id = "lobby-instance"
+dna_hash = "QmYF9JC7hbBqyThch4jRooXrXgh9EkgbDnTTQeRZ8mVvxQ"
+uri = "https://github.com/holochain-open-dev/community-mutual-credit/releases/download/test-0/lobby.dna.json"
+
+[[UIs]]
+name = "Community Mutual-Credit"
+uri = "https://github.com/holochain-open-dev/community-mutual-credit/releases/download/test-0/ui.zip"
+
+[[UIs.instance_references]]
+ui_handle = "lobby-instance"
+instance_id = "lobby-instance"


### PR DESCRIPTION
Adds the Holochain Community Mutual-Credit happ. This is an experiment combining two popular mechanisms around the holochain community:

- [Mutual-Credit](https://github.com/holochain-open-dev/mutual-credit): LETS style mutual credit implementation
- [Social triangulation membrane](https://github.com/holochain-open-dev/social-triangulation): only friends from friends are able to enter this DNA.

With this we want to achieve 3 goals:

- Experiment with these patterns and see what works and what doesn't, at the social layer and also at the security/technical layer.
- Arrive to an MVP like implementation of all modules. We have implemented the code in modular fashion, having the zomes available to download as git submodules and the UI code as NPM packages (documentation still to come).
- Engage the holochain community in a social game, and have fun! 

When this is merged, we'll announce it in the forum for people to begin participating in the game. The parameters set for the game are: 

- Negative credit limit: -100
- Necessary vouches for the social triangulation: 2

Right now, you cannot dynamically create new currencies, but in the near future you will be able to.