### PR TITLE
Remove Hylo Communities from index

### DIFF
--- a/index.json
+++ b/index.json
@@ -1,13 +1,5 @@
 [
   {
-    "name": "Communities",
-    "directory": "communities",
-    "github": "https://github.com/Holo-Host/holo-communities",
-    "icon": null,
-    "screenshot": "https://github.com/Holo-Host/holo-communities-dna/releases/download/holoscape-bundle-v0.0.4/holo-communities.png",
-    "description": "Communities app allows you to publish, read, comment on content, as well as message other Holochain users"
-  },
-  {
     "name": "Basic Chat",
     "directory": "basic-chat",
     "github": "https://github.com/willemolding/basic-chat",


### PR DESCRIPTION
Preparing to bless Holonix and cut a new Holoscape release with Holochain v0.0.49-alpha1. I think Communities hasn't been working for a while.