### PR TITLE
Holonix v0.0.11

### DIFF
--- a/index.json
+++ b/index.json
@@ -1,13 +1,5 @@
 [
   {
-    "name": "Communities",
-    "directory": "communities",
-    "github": "https://github.com/Holo-Host/holo-communities",
-    "icon": null,
-    "screenshot": "https://github.com/Holo-Host/holo-communities-dna/releases/download/holoscape-bundle-v0.0.4/holo-communities.png",
-    "description": "Communities app allows you to publish, read, comment on content, as well as message other Holochain users"
-  },
-  {
     "name": "Basic Chat",
     "directory": "basic-chat",
     "github": "https://github.com/willemolding/basic-chat",


### PR DESCRIPTION
Getting ready to bless Holonix .75 with Holochain .49, which means we'll be cutting a new release of Holoscape too. I don't think Hylo Communities has worked for a while, actually.